### PR TITLE
Add custom comparator input override to iron tanks

### DIFF
--- a/src/main/java/mods/railcraft/common/blocks/machine/BlockMachine.java
+++ b/src/main/java/mods/railcraft/common/blocks/machine/BlockMachine.java
@@ -355,7 +355,7 @@ public class BlockMachine extends BlockContainer implements IPostConnection {
     
     @Override
     public boolean hasComparatorInputOverride() {
-        if (proxy instanceof MachineProxyBeta)
+        if (proxy instanceof IComparatorOverride)
         	return true;
         return false;
     }
@@ -366,8 +366,8 @@ public class BlockMachine extends BlockContainer implements IPostConnection {
     @Override
     public int getComparatorInputOverride(World world, int x, int y, int z, int side) {
         TileEntity tile = world.getTileEntity(x, y, z);
-        if (tile instanceof IComparatorOverride)
-            return ((IComparatorOverride) tile).getComparatorInputOverride(world, x, y, z, side);
+        if (tile instanceof IComparatorValueProvider)
+            return ((IComparatorValueProvider) tile).getComparatorInputOverride(world, x, y, z, side);
         return 0;
     }
 

--- a/src/main/java/mods/railcraft/common/blocks/machine/BlockMachine.java
+++ b/src/main/java/mods/railcraft/common/blocks/machine/BlockMachine.java
@@ -28,6 +28,7 @@ import net.minecraft.util.IIcon;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
+import mods.railcraft.common.blocks.machine.beta.MachineProxyBeta;
 import mods.railcraft.common.plugins.forge.CreativePlugin;
 import mods.railcraft.common.plugins.forge.PowerPlugin;
 import mods.railcraft.common.util.misc.Game;
@@ -350,6 +351,24 @@ public class BlockMachine extends BlockContainer implements IPostConnection {
         if (tile instanceof TileMachineBase)
             return ((TileMachineBase) tile).getHardness();
         return super.getBlockHardness(world, x, y, z);
+    }
+    
+    @Override
+    public boolean hasComparatorInputOverride() {
+        if (proxy instanceof MachineProxyBeta)
+        	return true;
+        return false;
+    }
+
+    /**
+     * Value is provided by the tile entity
+     */
+    @Override
+    public int getComparatorInputOverride(World world, int x, int y, int z, int side) {
+        TileEntity tile = world.getTileEntity(x, y, z);
+        if (tile instanceof IComparatorOverride)
+            return ((IComparatorOverride) tile).getComparatorInputOverride(world, x, y, z, side);
+        return 0;
     }
 
     @Override

--- a/src/main/java/mods/railcraft/common/blocks/machine/IComparatorOverride.java
+++ b/src/main/java/mods/railcraft/common/blocks/machine/IComparatorOverride.java
@@ -1,0 +1,10 @@
+package mods.railcraft.common.blocks.machine;
+
+/**
+ * @author wshadow
+ * Marker interface; Machine proxys should implement this if (some of) the corresponding blocks
+ * tileentities implement IComparatorValueProvider
+ */
+public interface IComparatorOverride {
+
+}

--- a/src/main/java/mods/railcraft/common/blocks/machine/IComparatorValueProvider.java
+++ b/src/main/java/mods/railcraft/common/blocks/machine/IComparatorValueProvider.java
@@ -1,0 +1,12 @@
+package mods.railcraft.common.blocks.machine;
+
+import net.minecraft.world.World;
+
+/**
+ * @author wshadow
+ *
+ */
+public interface IComparatorValueProvider {
+	public int getComparatorInputOverride(World world, int x, int y, int z, int side);
+
+}

--- a/src/main/java/mods/railcraft/common/blocks/machine/beta/MachineProxyBeta.java
+++ b/src/main/java/mods/railcraft/common/blocks/machine/beta/MachineProxyBeta.java
@@ -13,6 +13,7 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.IIcon;
+import mods.railcraft.common.blocks.machine.IComparatorOverride;
 import mods.railcraft.common.blocks.machine.IEnumMachine;
 import mods.railcraft.common.blocks.machine.IMachineProxy;
 import mods.railcraft.common.gui.tooltips.ToolTip;
@@ -22,7 +23,7 @@ import net.minecraft.client.renderer.texture.IIconRegister;
  *
  * @author CovertJaguar <http://www.railcraft.info>
  */
-public class MachineProxyBeta implements IMachineProxy {
+public class MachineProxyBeta implements IMachineProxy, IComparatorOverride {
 
     @Override
     public String getTag(int meta) {

--- a/src/main/java/mods/railcraft/common/blocks/machine/beta/TileTankIronValve.java
+++ b/src/main/java/mods/railcraft/common/blocks/machine/beta/TileTankIronValve.java
@@ -12,7 +12,7 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.IIcon;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
-import mods.railcraft.common.blocks.machine.IComparatorOverride;
+import mods.railcraft.common.blocks.machine.IComparatorValueProvider;
 import mods.railcraft.common.blocks.machine.IEnumMachine;
 import mods.railcraft.common.fluids.FluidHelper;
 import mods.railcraft.common.fluids.TankManager;
@@ -30,7 +30,7 @@ import net.minecraftforge.fluids.IFluidHandler;
  *
  * @author CovertJaguar <http://www.railcraft.info>
  */
-public class TileTankIronValve extends TileTankBase implements IFluidHandler, IComparatorOverride {
+public class TileTankIronValve extends TileTankBase implements IFluidHandler, IComparatorValueProvider {
 
     private final static ITileFilter FLUID_OUTPUT_FILTER = new ITileFilter() {
         @Override

--- a/src/main/java/mods/railcraft/common/blocks/machine/beta/TileTankIronValve.java
+++ b/src/main/java/mods/railcraft/common/blocks/machine/beta/TileTankIronValve.java
@@ -10,7 +10,9 @@ package mods.railcraft.common.blocks.machine.beta;
 
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.IIcon;
+import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
+import mods.railcraft.common.blocks.machine.IComparatorOverride;
 import mods.railcraft.common.blocks.machine.IEnumMachine;
 import mods.railcraft.common.fluids.FluidHelper;
 import mods.railcraft.common.fluids.TankManager;
@@ -28,7 +30,7 @@ import net.minecraftforge.fluids.IFluidHandler;
  *
  * @author CovertJaguar <http://www.railcraft.info>
  */
-public class TileTankIronValve extends TileTankBase implements IFluidHandler {
+public class TileTankIronValve extends TileTankBase implements IFluidHandler, IComparatorOverride {
 
     private final static ITileFilter FLUID_OUTPUT_FILTER = new ITileFilter() {
         @Override
@@ -201,5 +203,14 @@ public class TileTankIronValve extends TileTankBase implements IFluidHandler {
             return tMan.getTankInfo();
         return FakeTank.INFO;
     }
+
+	@Override
+	public int getComparatorInputOverride(World world, int x, int y, int z,
+			int side) {
+		FluidTankInfo[] tankinfo = getTankInfo(ForgeDirection.getOrientation(side));
+		if (tankinfo != null && tankinfo.length == 1 && tankinfo[0] != null && tankinfo[0].fluid != null)
+		    return Math.round(tankinfo[0].fluid.amount*15/tankinfo[0].capacity);
+		return 0;
+	}
 
 }


### PR DESCRIPTION
Using this code, comparators can be used on tank valves to read how much liquid is in the tank.

Work in progress pull request. The current implementation requires the user to provide blockupdates to the comparator - without those the comparator doesn't update its value. I'd like to do the blockupdates only when necessary (i.e. the signalstrength will change) and only on the blocks adjacent to the tank valves instead of all blocks adjacent to the tank. I'm looking for ideas how (i.e. in which classes/methods) I could implement this. I'll update this pull request when I have figured out how to do that.