### PR TITLE
Reworked logic in TrackNextGenLocking.java

### DIFF
--- a/src/main/java/mods/railcraft/common/blocks/tracks/TrackNextGenLocking.java
+++ b/src/main/java/mods/railcraft/common/blocks/tracks/TrackNextGenLocking.java
@@ -13,6 +13,7 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.util.UUID;
+
 import mods.railcraft.api.core.items.IToolCrowbar;
 import mods.railcraft.api.events.CartLockdownEvent;
 import mods.railcraft.api.tracks.ITrackLockdown;
@@ -26,7 +27,6 @@ import mods.railcraft.common.carts.Train;
 import mods.railcraft.common.plugins.forge.LocalizationPlugin;
 import mods.railcraft.common.plugins.forge.ChatPlugin;
 import mods.railcraft.common.util.misc.Game;
-import net.minecraft.block.Block;
 import net.minecraft.entity.item.EntityMinecart;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
@@ -96,16 +96,21 @@ public class TrackNextGenLocking extends TrackBaseRailcraft implements ITrackLoc
 
     public static double START_BOOST = 0.04;
     public static double BOOST_FACTOR = 0.06;
-    protected boolean powered = false;
-    protected int prevDelay = 0;
-    protected int delay = 0;
-    protected byte reset = 0;
+    
     private LockingProfileType profile = LockingProfileType.LOCKDOWN;
     private LockingProfile profileInstance = profile.create(this);
-    private EntityMinecart lockedCart;
-    private Train currentTrain;
-    private int justLoaded = 20;
+    private EntityMinecart currentCart, prevCart;
     private UUID uuid;
+    private boolean trainLeaving = false;
+    private boolean redstone = false;
+    private boolean locked = false;
+    private int trainDelay = 0;
+    
+    // Temporary variables to hold loaded data while we restore from NBT
+    private UUID prevCartUUID;
+    private UUID currentCartUUID;
+    private boolean justLoaded = true;
+    
 
     @Override
     public EnumTrack getTrackType() {
@@ -114,9 +119,9 @@ public class TrackNextGenLocking extends TrackBaseRailcraft implements ITrackLoc
 
     @Override
     public IIcon getIcon() {
-        if (isPowered() || delay > 0)
-            return getIcon(profile.ordinal() * 2);
-        return getIcon(profile.ordinal() * 2 + 1);
+        if (!locked)
+            return getIcon(profile.ordinal() * 2); // glowing
+        return getIcon(profile.ordinal() * 2 + 1); // not glowing
     }
 
     public LockingProfileType getProfileType() {
@@ -135,37 +140,53 @@ public class TrackNextGenLocking extends TrackBaseRailcraft implements ITrackLoc
         return true;
     }
 
+    /**
+     * We try to calculate all the logic here so we can isolate it on the server side.
+     * Its a bit tricky to determine whether a cart or train is on top of us, but we can do it
+     * if we maintain a record of the last cart that was on us and the next cart that triggers
+     * an onMinecartPass() event.
+     */
     @Override
     public void updateEntity() {
+    	
         if (Game.isHost(getWorld())) {
-            if (justLoaded > 0)
-                justLoaded--;
-            if (getCurrentCart() != null && getCurrentCart().isDead)
-                setCurrentCartAndTrain(null);
-            if (isPowered())
-                delay = getDelayTime();
-            else if (delay > 0) {
-                delay--;
-                if (delay == 0)
-                    setCurrentCartAndTrain(null);
+        	boolean updateClient = false; // flag determines whether we send an update to the client, only update when visible changes occur
+        	        	
+        	// At the time we read from NBT, LinkageManager has not been initialized so we cannot
+        	// lookup the carts by UUID in readFromNBT(). We must wait until updateEntity(), which
+        	// occurs after LinkageManager gets initialized. The justLoaded flag lets us lookup 
+        	// the carts only after restoring from NBT.
+        	if(justLoaded) { 
+           		prevCart = LinkageManager.instance().getCartFromUUID(prevCartUUID);
+           		currentCart = LinkageManager.instance().getCartFromUUID(currentCartUUID);
+            	justLoaded = false;
+            	updateClient = true;
+        	}        	
+        	        	
+            if (currentCart != null && currentCart.isDead) {
+                releaseCart();
+                updateClient = true;
             }
-            if (reset > 0)
-                reset--;
-            if (prevDelay == 0 ^ delay == 0)
-                sendUpdateToClient();
-            prevDelay = delay;
+            boolean oldLocked = locked; // simple check to determine if "locked" has changed
+            calculateLocked();
+            if(oldLocked != locked)
+            	updateClient = true;
+            
+            if(locked) {
+            	lockCart();
+            } else {
+            	releaseCart();
+            }        
+            
+            // Store our last found cart in prevCart
+            if(currentCart != null)
+            	prevCart = currentCart;            
+            currentCart = null; // reset currentCart so we know if onMinecartPass() actually found one
+
+            if(updateClient)
+            	sendUpdateToClient();
         }
-    }
 
-    @Override
-    public void onNeighborBlockChange(Block blockChanged) {
-        super.onNeighborBlockChange(blockChanged);
-        if (isPowered())
-            delay = getDelayTime();
-    }
-
-    public EntityMinecart getCurrentCart() {
-        return lockedCart;
     }
 
     @Override
@@ -191,132 +212,172 @@ public class TrackNextGenLocking extends TrackBaseRailcraft implements ITrackLoc
 
     @Override
     public void onBlockRemoved() {
-        super.onBlockRemoved();
-        setCurrentCartAndTrain(null);
+        super.onBlockRemoved();   
+        releaseCart(); // Release any carts still holding on
     }
 
     private UUID getUUID() {
         if (uuid == null)
             uuid = UUID.randomUUID();
         return uuid;
-    }
+    }   
 
-    protected void setCurrentCartAndTrain(EntityMinecart cart) {
-        if (lockedCart != cart && lockedCart != null) {
-            Train train = LinkageManager.instance().getTrain(lockedCart);
-            train.removeLockingTrack(getUUID());
-        }
-        lockedCart = cart;
-        if (cart == null)
-            currentTrain = null;
-        else
-            currentTrain = LinkageManager.instance().getTrain(cart);
-    }
-
-    protected void lockCart(EntityMinecart cart) {
-        if (cart != null) {
-            Train train = LinkageManager.instance().getTrain(cart);
-            train.addLockingTrack(getUUID());
-            MinecraftForge.EVENT_BUS.post(new CartLockdownEvent.Lock(cart, getX(), getY(), getZ()));
-            profileInstance.onLock(cart);
-        }
-    }
-
-    protected void releaseCart(EntityMinecart cart) {
-        if (cart != null) {
-            Train train = LinkageManager.instance().getTrain(cart);
-            train.removeLockingTrack(getUUID());
-            MinecraftForge.EVENT_BUS.post(new CartLockdownEvent.Release(cart, getX(), getY(), getZ()));
-            profileInstance.onRelease(cart);
+    protected void lockCart() {
+        if (currentCart != null) {
+        	Train currentTrain = LinkageManager.instance().getTrain(currentCart);
+            currentTrain.addLockingTrack(getUUID());            
+            MinecraftForge.EVENT_BUS.post(new CartLockdownEvent.Lock(currentCart, getX(), getY(), getZ()));
+            profileInstance.onLock(currentCart);
+            currentCart.motionX = 0.0D;
+            currentCart.motionZ = 0.0D;
+            int meta = tileEntity.getBlockMetadata();
+            if (meta == 0 || meta == 4 || meta == 5)
+            	currentCart.posZ = tileEntity.zCoord + 0.5D;
+            else
+            	currentCart.posX = tileEntity.xCoord + 0.5D; 
         }
     }
 
     @Override
     public void onMinecartPass(EntityMinecart cart) {
-        checkIfShouldChangeCart(cart);
-        if (isPowered() || delay > 0)
-            releaseCart(cart);
-        else {
-            if (getCurrentCart() == null)
-                setCurrentCartAndTrain(cart);
-            if (getCurrentCart() == cart) {
-                lockCart(cart);
-                cart.motionX = 0.0D;
-                cart.motionZ = 0.0D;
-                int meta = tileEntity.getBlockMetadata();
-                if (meta == 0 || meta == 4 || meta == 5)
-                    cart.posZ = tileEntity.zCoord + 0.5D;
-                else
-                    cart.posX = tileEntity.xCoord + 0.5D;
-            }
-        }
-    }
-
-    protected void checkIfShouldChangeCart(EntityMinecart cart) {
-        int r = reset;
-        reset = 20;
-
-        if (delay <= 0) {
-            justLoaded = 0;
-            return;
-        }
-
-        if (justLoaded > 0) {
-            setCurrentCartAndTrain(cart);
-            delay = getDelayTime();
-            justLoaded = 0;
-            return;
-        }
-
-        if (r <= 0
-                || (profile.lockType == LockType.CART && lockedCart != cart)
-                || (profile.lockType == LockType.TRAIN && currentTrain != LinkageManager.instance().getTrain(cart))) {
-            delay = 0;
-            setCurrentCartAndTrain(cart);
-            return;
-        }
-        if (profile.lockType == LockType.TRAIN)
-            delay = getDelayTime();
-    }
-
-    protected int getDelayTime() {
-        if (profile.lockType == LockType.TRAIN)
-            return TrackTools.TRAIN_LOCKDOWN_DELAY;
-        return 3;
+    	currentCart = cart;       
     }
 
     @Override
     public void releaseCart() {
-        delay = 10;
+    	if (currentCart != null) {
+            Train train = LinkageManager.instance().getTrain(currentCart);
+            train.removeLockingTrack(getUUID());
+            MinecraftForge.EVENT_BUS.post(new CartLockdownEvent.Release(currentCart, getX(), getY(), getZ()));
+            profileInstance.onRelease(currentCart);  
+        }
     }
 
     @Override
     public boolean isCartLockedDown(EntityMinecart cart) {
-        return !powered && lockedCart == cart && delay == 0;
+        return locked && prevCart == cart;
+    }
+    
+    
+    /**
+     * Determines if the current train is the same train or cart (depending on track type)
+     * as the train or cart in previous ticks. The <code>trainDelay</code> is needed because there are
+     * gaps between carts in a train where onMinecartPass() doesn't get called even though
+     * the train is still passing over us.
+     * @return whether the current cart or train (depending on LockType) is the same as previous cart or trains
+     */
+    private boolean isSameTrainOrCart() {    	
+    	if(profile.lockType == LockType.TRAIN) {
+    		Train currentTrain = LinkageManager.instance().getTrain(currentCart);
+    		if(currentTrain != null) {
+    			Train prevTrain = LinkageManager.instance().getTrain(prevCart);
+    			if(currentTrain == prevTrain) {
+    				trainDelay = TrackTools.TRAIN_LOCKDOWN_DELAY; // reset trainDelay
+    			} else {
+    				trainDelay = 0; // We've encountered a new train, force the delay to 0 so we return false
+    			}
+    		}
+    		if(trainDelay > 0)
+        		trainDelay--;
+    		else
+    			prevCart = null;    		
+        	return trainDelay > 0;
+    	} else {
+    		return currentCart != null && 
+        			(profile.lockType == LockType.CART && currentCart == prevCart);
+    	}
+    }
+    
+    /**
+     * The heart of the logic for this class is done here. If you understand what's going
+     * on here, the rest will make much more sense to you. Basically, we're trying to determine
+     * whether this track should be trying to lock the current or next cart that passes over it.
+     * First of all we must realize that we only have 2 inputs: 1) whether a train/cart
+     * is passing over us and 2) whether our track is receiving a redstone signal. If we try to
+     * create a truth table with 2 boolean inputs to calculate "locked", we find that we can't quite
+     * express the correct value for "locked". When we analyze the situation, we notice that when
+     * a train is passing over the track, we need both the redstone to be off and the last cart to be
+     * off the track in order to lock the track. However after the train has already left the track, 
+     * then we want the track to be "locked" when the redstone is off, regardless of whether a
+     * new or old cart starts moving onto the track. In the end, what we're really after is
+     * having 2 truth tables and a way to decide which of the 2 tables to use. To do this, we
+     * use the boolean <code>trainLeaving</code> to indicate which table to use. As the name
+     * implies, <code>trainLeaving</code> indicates whether the train or cart is in the process
+     * of leaving the track.   
+     */
+    private void calculateLocked() {    	
+		boolean isSameCart = isSameTrainOrCart();
+		if(trainLeaving) {
+			if(!isSameCart && !redstone) { 
+				// When the train is in the process of leaving, we know that the "trainLeaving" state ends 
+				// when both the carts and redstone signal are false 
+				trainLeaving = false;
+			}
+			locked = !(isSameCart || redstone);
+		} else {			
+			if(isSameCart && redstone) { // When we get both signals we know a train is leaving, so we set the state as so
+				trainLeaving = true;
+			}
+			locked = !redstone;    		
+		}
     }
 
     @Override
-    public boolean isPowered() {
-        return powered;
+    public boolean isPowered() {    	
+    	return redstone; // Why call this "redstone" instead of "powered"? Powered gives the impression that
+    	// the track will accelerate or unlock a cart and for this track we cannot assume that
+    	// having a redstone signal applied is equivalent to being powered. Based on the usage
+    	// of the isPowered()/setPowered() calls, it seems that they more accurately describe
+    	// whether a redstone signal is being applied. I have refrained from using "powered" in the code
+    	// in the hopes that the logic is easier to understand.
     }
 
     @Override
     public void setPowered(boolean powered) {
-        this.powered = powered;
+        this.redstone = powered;
     }
 
+    /**
+     * A utility method for writing out UUID's to NBT 
+     */
+    private void setUUID(UUID id, String key, NBTTagCompound data) {
+    	if(id == null) {
+    		data.setLong(key+"High", 0);
+    		data.setLong(key+"Low", 0);
+    	} else {
+    		data.setLong(key+"High", id.getMostSignificantBits());
+    		data.setLong(key+"Low", id.getLeastSignificantBits());
+    	}
+    }
+    
+    /**
+     * A utility method for reading in UUID's from NBT
+     */
+    private UUID readUUID(String key, NBTTagCompound data) {
+    	 if (data.hasKey(key + "High"))
+             return new UUID(data.getLong(key + "High"), data.getLong(key + "Low"));
+    	 return null;
+    }
+    
     @Override
     public void writeToNBT(NBTTagCompound data) {
         super.writeToNBT(data);
         data.setByte("profile", (byte) profile.ordinal());
         profileInstance.writeToNBT(data);
-        data.setBoolean("powered", powered);
-        data.setInteger("delay", delay);
-        data.setByte("reset", reset);
-        data.setLong("uuidHigh", getUUID().getMostSignificantBits());
-        data.setLong("uuidLow", getUUID().getLeastSignificantBits());
+        data.setBoolean("powered", redstone);
+        data.setBoolean("locked", locked);
+        data.setBoolean("trainLeaving", trainLeaving);
+        data.setInteger("trainDelay", trainDelay);
+        if(prevCart != null)
+        	setUUID(prevCart.getPersistentID(), "prevCart", data);
+        if(currentCart != null)
+        	setUUID(currentCart.getPersistentID(), "currentCart", data);
+        
+        setUUID(getUUID(), "uuid", data);
     }
-
+    
+    
+    
     @Override
     public void readFromNBT(NBTTagCompound data) {
         super.readFromNBT(data);
@@ -324,12 +385,25 @@ public class TrackNextGenLocking extends TrackBaseRailcraft implements ITrackLoc
             profile = LockingProfileType.fromOrdinal(data.getByte("profile"));
         profileInstance = profile.create(this);
         profileInstance.readFromNBT(data);
-        powered = data.getBoolean("powered");
-        delay = data.getInteger("delay");
-        reset = data.getByte("reset");
+        redstone = data.getBoolean("powered");
+        
+        if(data.hasKey("locked"))
+        	locked = data.getBoolean("locked");
+                
+        if(data.hasKey("trainLeaving"))
+        	trainLeaving = data.getBoolean("trainLeaving");
+                
+        if(data.hasKey("trainDelay"))
+        	trainDelay = data.getInteger("trainDelay");        
 
-        if (data.hasKey("uuidHigh"))
-            uuid = new UUID(data.getLong("uuidHigh"), data.getLong("uuidLow"));
+        prevCartUUID = readUUID("prevCart", data);  
+        currentCartUUID = readUUID("currentCart", data);
+        
+        uuid = readUUID("uuid", data);
+        
+        justLoaded = true; // This signals updateEntity() to dereference the cart UUID's we read in here
+        
+        System.out.println("Read from NBT");
     }
 
     @Override
@@ -337,9 +411,9 @@ public class TrackNextGenLocking extends TrackBaseRailcraft implements ITrackLoc
         super.writePacketData(data);
 
         data.writeByte(profile.ordinal());
-        data.writeBoolean(powered);
-        data.writeShort(delay);
-
+        data.writeBoolean(redstone);
+        data.writeBoolean(locked);
+               
         profileInstance.writePacketData(data);
     }
 
@@ -352,9 +426,8 @@ public class TrackNextGenLocking extends TrackBaseRailcraft implements ITrackLoc
             profile = p;
             profileInstance = p.create(this);
         }
-        powered = data.readBoolean();
-        delay = data.readShort();
-
+        redstone = data.readBoolean();
+        locked = data.readBoolean();        
         profileInstance.readPacketData(data);
 
         markBlockNeedsUpdate();


### PR DESCRIPTION
These changes allow the track to become unpowered immediately if a train hasn't recently crossed over it.
It also fixes an issue where upon restoring from NBT, the train gets held by a locking track that was in the middle of releasing it but was no longer powered by redstone. 
This seems to be caused by train instances that change a few ticks after loading. For instance, when initially calling LinkageManager.getTrain(cart) you will get one instance
of Train (id=1), but on another tick you would get Train (id=2) even though you used the same cart instance in both calls. Once the game stabilizes, the Train instances also
stabilize so we don't see the issue normally. The fix was to only store cart references across ticks (not trains) then when we need to compare trains, simply call LinkageManager.getTrain()
on each cart which guarantees that the train returned will be the same. 
The rest of the changes were to eliminate as many timers/delays as possible and rely on the state of the world as much as possible.