### PR TITLE
Fix missing Block Sounds on SMP

### DIFF
--- a/src/main/java/mods/railcraft/client/sounds/RCSoundHandler.java
+++ b/src/main/java/mods/railcraft/client/sounds/RCSoundHandler.java
@@ -37,15 +37,24 @@ public class RCSoundHandler {
     public void onPlaySound(PlaySoundEvent17 event) {
         String soundName = event.name;
         if (soundName != null && event.sound instanceof PositionedSoundRecord && soundName.contains("railcraft")) {
-            World world = Railcraft.getProxy().getClientWorld();
+            World world = Railcraft.getProxy().getClientWorld();            
             if (world != null) {
+            	SoundType sound = null;
                 float x = event.sound.getXPosF();
                 float y = event.sound.getYPosF();
                 float z = event.sound.getZPosF();
                 int ix = MathHelper.floor_float(x);
                 int iy = MathHelper.floor_float(y);
                 int iz = MathHelper.floor_float(z);
-                SoundType sound = getBlockSound(world, ix, iy, iz);
+                if (soundName.contains("place") && getBlockSound(world, ix, iy, iz) == null) {
+                	event.manager.addDelayedSound(event.sound, 3); //Play sound later if client is lagging.
+                } else if (soundName.contains("step")) {
+                	sound = getBlockSound(world, ix, iy - 1, iz); //Check for block below where step happens.
+                		if (sound == null) {
+                			sound = getBlockSound(world, ix, iy, iz);} //Check if step was on a half-block.
+                } else {
+                    sound = getBlockSound(world, ix, iy, iz);
+                }
                 if (sound != null) {
                     String newName = sound.getStepResourcePath();
                     if (soundName.contains("dig"))
@@ -53,25 +62,6 @@ public class RCSoundHandler {
                     else if (soundName.contains("place"))
                         newName = sound.func_150496_b();
                     event.result = new PositionedSoundRecord(new ResourceLocation(newName), event.sound.getVolume(), event.sound.getPitch() * sound.getPitch(), x, y, z);
-                }
-            }
-        }
-    }
-
-    @SubscribeEvent
-    public void onPlaySoundAtEntity(PlaySoundAtEntityEvent event) {
-        String soundName = event.name;
-        Entity entity = event.entity;
-        if (soundName != null && soundName.equals("step.railcraft")) {
-            World world = entity.worldObj;
-            if (world != null) {
-                int ix = MathHelper.floor_double(entity.posX);
-                int iy = MathHelper.floor_double(entity.posY - 0.2 - (double) entity.yOffset);
-                int iz = MathHelper.floor_double(entity.posZ);
-                SoundType sound = getBlockSound(world, ix, iy, iz);
-                if (sound != null) {
-                    world.playSoundAtEntity(entity, sound.getStepResourcePath(), event.volume, event.pitch * sound.getPitch());
-                    event.setCanceled(true);
                 }
             }
         }

--- a/src/main/java/mods/railcraft/client/sounds/RCSoundHandler.java
+++ b/src/main/java/mods/railcraft/client/sounds/RCSoundHandler.java
@@ -37,23 +37,21 @@ public class RCSoundHandler {
     public void onPlaySound(PlaySoundEvent17 event) {
         String soundName = event.name;
         if (soundName != null && event.sound instanceof PositionedSoundRecord && soundName.contains("railcraft")) {
-            World world = Railcraft.getProxy().getClientWorld();            
+            World world = Railcraft.getProxy().getClientWorld();
             if (world != null) {
-            	SoundType sound = null;
                 float x = event.sound.getXPosF();
                 float y = event.sound.getYPosF();
                 float z = event.sound.getZPosF();
                 int ix = MathHelper.floor_float(x);
                 int iy = MathHelper.floor_float(y);
                 int iz = MathHelper.floor_float(z);
-                if (soundName.contains("place") && getBlockSound(world, ix, iy, iz) == null) {
-                	event.manager.addDelayedSound(event.sound, 3); //Play sound later if client is lagging.
-                } else if (soundName.contains("step")) {
-                	sound = getBlockSound(world, ix, iy - 1, iz); //Check for block below where step happens.
-                		if (sound == null) {
-                			sound = getBlockSound(world, ix, iy, iz);} //Check if step was on a half-block.
-                } else {
-                    sound = getBlockSound(world, ix, iy, iz);
+                SoundType sound = getBlockSound(world, ix, iy, iz);
+                if (sound == null) {
+	                if (soundName.contains("place")) {
+	                	event.manager.addDelayedSound(event.sound, 3); //Play sound later to adjust for the block not being there yet.
+	                } else if (soundName.contains("step")) {
+	                	sound = getBlockSound(world, ix, iy - 1, iz);
+	                }
                 }
                 if (sound != null) {
                     String newName = sound.getStepResourcePath();


### PR DESCRIPTION
After some testing, this fixes the missing step-sounds on SMP Servers for blocks using the custom sound handler.

It also fixes the block-place sound for the same blocks that use this custom sound handler, however I have only been able to test this on locally hosted servers and am unsure if latency would stop the block-place sound from working.

onPlaySoundAtEntity was causing location issues when called from a client connected to an SMP Server. So it seemed redundant at this point and, considering sounds that it played seemed to get parsed through the onPlaySound handler anyways, I have removed it.