### PR TITLE
Fix for chunkload switch errors

### DIFF
--- a/src/main/java/mods/railcraft/common/blocks/signals/TileSwitchLever.java
+++ b/src/main/java/mods/railcraft/common/blocks/signals/TileSwitchLever.java
@@ -8,6 +8,8 @@
  */
 package mods.railcraft.common.blocks.signals;
 
+import mods.railcraft.api.tracks.ITrackSwitch;
+import net.minecraft.entity.item.EntityMinecart;
 import net.minecraft.entity.player.EntityPlayer;
 
 public class TileSwitchLever extends TileSwitchBase {
@@ -20,7 +22,12 @@ public class TileSwitchLever extends TileSwitchBase {
     @Override
     public boolean blockActivated(int side, EntityPlayer player) {
         setPowered(!isPowered());
-        switchTrack(isPowered());
         return true;
+    }
+
+    @Override
+    public boolean shouldSwitch(ITrackSwitch switchTrack, EntityMinecart cart) {
+        super.shouldSwitch(switchTrack, cart);
+        return isPowered();
     }
 }

--- a/src/main/java/mods/railcraft/common/blocks/signals/TileSwitchMotor.java
+++ b/src/main/java/mods/railcraft/common/blocks/signals/TileSwitchMotor.java
@@ -12,11 +12,13 @@ import mods.railcraft.api.signals.SimpleSignalReceiver;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import net.minecraft.entity.item.EntityMinecart;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.nbt.NBTTagCompound;
 import mods.railcraft.api.signals.IReceiverTile;
 import mods.railcraft.api.signals.SignalAspect;
 import mods.railcraft.api.signals.SignalController;
+import mods.railcraft.api.tracks.ITrackSwitch;
 import mods.railcraft.common.gui.EnumGui;
 import mods.railcraft.common.gui.GuiHandler;
 import mods.railcraft.common.util.misc.Game;
@@ -56,7 +58,6 @@ public class TileSwitchMotor extends TileSwitchSecured implements IAspectActionM
         boolean active = isSwitchAspect();
         if (switchAspect != active) {
             switchAspect = active;
-            switchTrack(switchAspect || isPowered());
         }
     }
 
@@ -70,7 +71,6 @@ public class TileSwitchMotor extends TileSwitchSecured implements IAspectActionM
         boolean power = isBeingPoweredByRedstone();
         if (isPowered() != power) {
             setPowered(power);
-            switchTrack(switchAspect || isPowered());
         }
     }
 
@@ -164,6 +164,12 @@ public class TileSwitchMotor extends TileSwitchSecured implements IAspectActionM
     @Override
     public SimpleSignalReceiver getReceiver() {
         return receiver;
+    }
+
+    @Override
+    public boolean shouldSwitch(ITrackSwitch switchTrack, EntityMinecart cart) {
+        super.shouldSwitch(switchTrack, cart);
+        return switchAspect || isPowered();
     }
 
 }

--- a/src/main/java/mods/railcraft/common/blocks/signals/TileSwitchRouting.java
+++ b/src/main/java/mods/railcraft/common/blocks/signals/TileSwitchRouting.java
@@ -8,11 +8,7 @@
  */
 package mods.railcraft.common.blocks.signals;
 
-import java.util.List;
-import mods.railcraft.api.tracks.ITrackInstance;
 import mods.railcraft.api.tracks.ITrackSwitch;
-import mods.railcraft.common.blocks.tracks.TileTrack;
-import mods.railcraft.common.carts.CartUtils;
 import mods.railcraft.common.gui.EnumGui;
 import mods.railcraft.common.gui.GuiHandler;
 import mods.railcraft.common.gui.buttons.MultiButtonController;
@@ -21,14 +17,12 @@ import mods.railcraft.common.util.inventory.InvTools;
 import mods.railcraft.common.util.inventory.StandaloneInventory;
 import mods.railcraft.common.util.misc.Game;
 import net.minecraft.block.Block;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.item.EntityMinecart;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.tileentity.TileEntity;
-import net.minecraft.util.AxisAlignedBB;
-import net.minecraftforge.common.util.ForgeDirection;
 
 public class TileSwitchRouting extends TileSwitchSecured implements IRouter, IRoutingTile {
 
@@ -73,38 +67,16 @@ public class TileSwitchRouting extends TileSwitchSecured implements IRouter, IRo
     }
 
     @Override
-    public void updateEntity() {
-        super.updateEntity();
-        if (Game.isNotHost(worldObj))
-            return;
-        refreshLogic();
-        boolean shouldSwitch = false;
-        for (byte side = 2; side < 6; side++) {
-            TileEntity tile = tileCache.getTileOnSide(ForgeDirection.getOrientation(side));
-            if (tile instanceof TileTrack) {
-                ITrackInstance track = ((TileTrack) tile).getTrackInstance();
-                shouldSwitch |= track instanceof ITrackSwitch && isRoutedCartApproaching((ITrackSwitch) track);
-            } else
-                shouldSwitch |= tile instanceof ITrackSwitch && isRoutedCartApproaching((ITrackSwitch) tile);
-        }
-        switchTrack(shouldSwitch);
-    }
-
-    private boolean isRoutedCartApproaching(ITrackSwitch track) {
-        if (logic == null || !logic.isValid())
-            return false;
-        AxisAlignedBB searchBox = track.getRoutingSearchBox();
-        List<EntityMinecart> carts = CartUtils.getMinecartsIn(worldObj, searchBox);
-        for (EntityMinecart cart : carts) {
-            if (logic.matches(this, cart))
-                return true;
-        }
-        return false;
+    public void onNeighborBlockChange(Block block) {
+        super.onNeighborBlockChange(block);
+        boolean power = isBeingPoweredByRedstone();
+        if (isPowered() != power)
+            setPowered(power);
     }
 
     @Override
-    public void onNeighborBlockChange(Block block) {
-        super.onNeighborBlockChange(block);
+    public void onBlockPlacedBy(EntityLivingBase entityliving, ItemStack stack) {
+        super.onBlockPlacedBy(entityliving, stack);
         boolean power = isBeingPoweredByRedstone();
         if (isPowered() != power)
             setPowered(power);
@@ -149,6 +121,16 @@ public class TileSwitchRouting extends TileSwitchSecured implements IRouter, IRo
     @Override
     public IInventory getInventory() {
         return inv;
+    }
+
+    @Override
+    public boolean shouldSwitch(ITrackSwitch switchTrack, EntityMinecart cart) {
+        super.shouldSwitch(switchTrack, cart);
+        RoutingLogic logic = getLogic();
+        if(logic != null && logic.isValid())
+            return logic.matches(this, cart);
+        else
+            return false; 
     }
 
 }

--- a/src/main/java/mods/railcraft/common/blocks/tracks/TrackSwitch.java
+++ b/src/main/java/mods/railcraft/common/blocks/tracks/TrackSwitch.java
@@ -11,13 +11,16 @@ package mods.railcraft.common.blocks.tracks;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.util.List;
+import java.util.UUID;
+import mods.railcraft.api.tracks.ISwitchDevice;
+import mods.railcraft.api.tracks.ITrackReversable;
+import mods.railcraft.common.blocks.RailcraftTileEntity;
+import mods.railcraft.common.carts.CartUtils;
 import net.minecraft.entity.item.EntityMinecart;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.IIcon;
-import mods.railcraft.api.carts.CartTools;
-import mods.railcraft.api.tracks.ITrackReversable;
-import mods.railcraft.common.util.misc.MiscTools;
-import net.minecraft.util.AxisAlignedBB;
 import net.minecraftforge.common.util.ForgeDirection;
 
 public class TrackSwitch extends TrackSwitchBase implements ITrackReversable {
@@ -44,7 +47,7 @@ public class TrackSwitch extends TrackSwitchBase implements ITrackReversable {
     @Override
     public int getBasicRailMetadata(EntityMinecart cart) {
         int meta = tileEntity.getBlockMetadata();
-        if (cart != null && isSwitched()) {
+        if (cart != null && isSwitched(cart)) {
             if (meta == EnumTrackMeta.NORTH_SOUTH.ordinal()) {
                 if (isMirrored()) {
                     if (reversed) {
@@ -79,7 +82,7 @@ public class TrackSwitch extends TrackSwitchBase implements ITrackReversable {
     }
 
     @Override
-    protected boolean shouldLockSwitch() {
+    protected List<UUID> getCartsAtLockEntrance() {
         int x = tileEntity.xCoord;
         int y = tileEntity.yCoord;
         int z = tileEntity.zCoord;
@@ -97,11 +100,33 @@ public class TrackSwitch extends TrackSwitchBase implements ITrackReversable {
                 x--;
             }
         }
-        return CartTools.isMinecartOnRailAt(getWorld(), x, y, z, 0.3f);
+        return CartUtils.getMinecartUUIDsAt(getWorld(), x, y, z, 0.1f);
     }
 
     @Override
-    protected boolean shouldSpringSwitch() {
+    protected List<UUID> getCartsAtDecisionEntrance() {
+        int x = tileEntity.xCoord;
+        int y = tileEntity.yCoord;
+        int z = tileEntity.zCoord;
+        int meta = tileEntity.getBlockMetadata();
+        if (meta == EnumTrackMeta.NORTH_SOUTH.ordinal()) {
+            if (isReversed() != isMirrored()) {
+                z--;
+            } else {
+                z++;
+            }
+        } else if (meta == EnumTrackMeta.EAST_WEST.ordinal()) {
+            if (!isReversed() != isMirrored()) {
+                x--;
+            } else {
+                x++;
+            }
+        }
+        return CartUtils.getMinecartUUIDsAt(getWorld(), x, y, z, 0.1f);
+    }
+
+    @Override
+    protected List<UUID> getCartsAtSpringEntrance() {
         int x = tileEntity.xCoord;
         int y = tileEntity.yCoord;
         int z = tileEntity.zCoord;
@@ -119,7 +144,7 @@ public class TrackSwitch extends TrackSwitchBase implements ITrackReversable {
                 z++;
             }
         }
-        return CartTools.isMinecartOnRailAt(getWorld(), x, y, z, 0.3f);
+        return CartUtils.getMinecartUUIDsAt(getWorld(), x, y, z, 0.1f);
     }
 
     @Override
@@ -154,25 +179,6 @@ public class TrackSwitch extends TrackSwitchBase implements ITrackReversable {
     @Override
     public boolean isReversed() {
         return reversed;
-    }
-
-    @Override
-    public AxisAlignedBB getRoutingSearchBox() {
-        ForgeDirection side = ForgeDirection.SOUTH;
-        if (tileEntity.getBlockMetadata() == 1) {
-            if (isReversed() != isMirrored()) {
-                side = ForgeDirection.WEST;
-            } else {
-                side = ForgeDirection.EAST;
-            }
-        } else if (isReversed() != isMirrored()) {
-            side = ForgeDirection.NORTH;
-        }
-        AxisAlignedBB box = AxisAlignedBB.getBoundingBox(0, 0, 0, 1, 1, 1);
-        box = MiscTools.addCoordToAABB(box, side.offsetX, 0, side.offsetZ);
-        box = MiscTools.addCoordToAABB(box, side.offsetX + 1, 1, side.offsetZ + 1);
-        box = box.offset(getX(), getY(), getZ());
-        return box;
     }
 
     @Override
@@ -213,6 +219,31 @@ public class TrackSwitch extends TrackSwitchBase implements ITrackReversable {
             return ArrowDirection.NORTH_SOUTH;
         }
         return ArrowDirection.EAST_WEST;
+    }
+
+    @Override
+    public ISwitchDevice getSwitchDevice() {
+        ForgeDirection dir = ForgeDirection.NORTH;
+        int meta = tileEntity.getBlockMetadata();
+        if (meta == EnumTrackMeta.NORTH_SOUTH.ordinal()) {
+            if (isMirrored()) {
+                dir = ForgeDirection.EAST;
+            } else {
+                dir = ForgeDirection.WEST;
+            }
+        } else if (meta == EnumTrackMeta.EAST_WEST.ordinal()) {
+            if (isMirrored()) {
+                dir = ForgeDirection.SOUTH;
+            } else {
+                dir = ForgeDirection.NORTH;
+            }
+        }
+        TileEntity entity = ((RailcraftTileEntity) this.tileEntity).getTileCache().getTileOnSide(dir);
+        if(entity instanceof ISwitchDevice && !entity.isInvalid()) {
+            return (ISwitchDevice)entity;
+        } else {
+            return null;
+        }
     }
 
 }

--- a/src/main/java/mods/railcraft/common/blocks/tracks/TrackWye.java
+++ b/src/main/java/mods/railcraft/common/blocks/tracks/TrackWye.java
@@ -8,10 +8,14 @@
  */
 package mods.railcraft.common.blocks.tracks;
 
+import java.util.List;
+import java.util.UUID;
+import mods.railcraft.api.tracks.ISwitchDevice;
+import mods.railcraft.common.blocks.RailcraftTileEntity;
+import mods.railcraft.common.carts.CartUtils;
 import net.minecraft.entity.item.EntityMinecart;
+import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.IIcon;
-import mods.railcraft.api.carts.CartTools;
-import net.minecraft.util.AxisAlignedBB;
 import net.minecraftforge.common.util.ForgeDirection;
 
 public class TrackWye extends TrackSwitchBase {
@@ -35,13 +39,13 @@ public class TrackWye extends TrackSwitchBase {
         if (cart != null) {
             if (meta == EnumTrackMeta.NORTH_SOUTH.ordinal()) {
                 if (isMirrored()) {
-                    if (isSwitched()) {
+                    if (isSwitched(cart)) {
                         meta = EnumTrackMeta.WEST_NORTH_CORNER.ordinal();
                     } else {
                         meta = EnumTrackMeta.WEST_SOUTH_CORNER.ordinal();
                     }
                 } else {
-                    if (isSwitched()) {
+                    if (isSwitched(cart)) {
                         meta = EnumTrackMeta.EAST_SOUTH_CORNER.ordinal();
                     } else {
                         meta = EnumTrackMeta.EAST_NORTH_CORNER.ordinal();
@@ -49,13 +53,13 @@ public class TrackWye extends TrackSwitchBase {
                 }
             } else if (meta == EnumTrackMeta.EAST_WEST.ordinal()) {
                 if (isMirrored()) {
-                    if (isSwitched()) {
+                    if (isSwitched(cart)) {
                         meta = EnumTrackMeta.EAST_NORTH_CORNER.ordinal();
                     } else {
                         meta = EnumTrackMeta.WEST_NORTH_CORNER.ordinal();
                     }
                 } else {
-                    if (isSwitched()) {
+                    if (isSwitched(cart)) {
                         meta = EnumTrackMeta.WEST_SOUTH_CORNER.ordinal();
                     } else {
                         meta = EnumTrackMeta.EAST_SOUTH_CORNER.ordinal();
@@ -67,7 +71,7 @@ public class TrackWye extends TrackSwitchBase {
     }
 
     @Override
-    protected boolean shouldLockSwitch() {
+    protected List<UUID> getCartsAtLockEntrance() {
         int x = tileEntity.xCoord;
         int y = tileEntity.yCoord;
         int z = tileEntity.zCoord;
@@ -85,11 +89,33 @@ public class TrackWye extends TrackSwitchBase {
                 z--;
             }
         }
-        return CartTools.isMinecartOnRailAt(getWorld(), x, y, z, 0.3f);
+        return CartUtils.getMinecartUUIDsAt(getWorld(), x, y, z, 0.1f);
     }
 
     @Override
-    protected boolean shouldSpringSwitch() {
+    protected List<UUID> getCartsAtDecisionEntrance() {
+        int x = tileEntity.xCoord;
+        int y = tileEntity.yCoord;
+        int z = tileEntity.zCoord;
+        int meta = tileEntity.getBlockMetadata();
+        if (meta == EnumTrackMeta.EAST_WEST.ordinal()) {
+            if (isMirrored()) {
+                z--;
+            } else {
+                z++;
+            }
+        } else if (meta == EnumTrackMeta.NORTH_SOUTH.ordinal()) {
+            if (isMirrored()) {
+                x--;
+            } else {
+                x++;
+            }
+        }
+        return CartUtils.getMinecartUUIDsAt(getWorld(), x, y, z, 0.1f);
+    }
+
+    @Override
+    protected List<UUID> getCartsAtSpringEntrance() {
         int x = tileEntity.xCoord;
         int y = tileEntity.yCoord;
         int z = tileEntity.zCoord;
@@ -107,27 +133,7 @@ public class TrackWye extends TrackSwitchBase {
                 z++;
             }
         }
-        return CartTools.isMinecartOnRailAt(getWorld(), x, y, z, 0.3f);
-    }
-
-    @Override
-    public AxisAlignedBB getRoutingSearchBox() {
-        ForgeDirection side = ForgeDirection.WEST;
-        if (EnumTrackMeta.EAST_WEST.isEqual(tileEntity.getBlockMetadata())) {
-            if (isMirrored()) {
-                side = ForgeDirection.NORTH;
-            } else {
-                side = ForgeDirection.SOUTH;
-            }
-        }
-        if (isMirrored()) {
-            side = ForgeDirection.EAST;
-        }
-        AxisAlignedBB box = AxisAlignedBB.getBoundingBox(0, 0, 0, 1, 1, 1);
-        box = box.addCoord(side.offsetX, side.offsetY, side.offsetZ);
-        box = box.addCoord(side.offsetX + 1, side.offsetY + 1, side.offsetZ + 1);
-        box = box.offset(getX(), getY(), getZ());
-        return box;
+        return CartUtils.getMinecartUUIDsAt(getWorld(), x, y, z, 0.1f);
     }
 
     @Override
@@ -170,4 +176,28 @@ public class TrackWye extends TrackSwitchBase {
         return ArrowDirection.WEST;
     }
 
+    @Override
+    public ISwitchDevice getSwitchDevice() {
+        ForgeDirection dir = ForgeDirection.NORTH;
+        int meta = tileEntity.getBlockMetadata();
+        if (meta == EnumTrackMeta.EAST_WEST.ordinal()) {
+            if (isMirrored()) {
+                dir = ForgeDirection.SOUTH;
+            } else {
+                dir = ForgeDirection.NORTH;
+            }
+        } else if (meta == EnumTrackMeta.NORTH_SOUTH.ordinal()) {
+            if (isMirrored()) {
+                dir = ForgeDirection.EAST;
+            } else {
+                dir = ForgeDirection.WEST;
+            }
+        }
+        TileEntity entity = ((RailcraftTileEntity) this.tileEntity).getTileCache().getTileOnSide(dir);
+        if(entity instanceof ISwitchDevice && !entity.isInvalid()) {
+            return (ISwitchDevice)entity;
+        } else {
+            return null;
+        }
+    }
 }


### PR DESCRIPTION
You will need the pull request in the railcraft-api https://github.com/CovertJaguar/Railcraft-API/pull/7

I added the onBlockPlacedBy() handler to TileSwitchRouting since it wasn't detecting a pre-existing redstone signal when the switch is placed.

Switch tracks now implement getSwitchDevice() and it gets called every tick to find a valid the switch device. If one is found, its shouldSwitch() method is called (also on every tick).
Similarly, the switch device uses shouldSwitch() to determine what it's switch track is. It too checks the track for validity in its getter.