### PR TITLE
Made the Signal Block Relay Box more expensive

### DIFF
--- a/src/main/java/mods/railcraft/common/modules/ModuleSignals.java
+++ b/src/main/java/mods/railcraft/common/modules/ModuleSignals.java
@@ -197,7 +197,7 @@ public class ModuleSignals extends RailcraftModule {
                         "IRI",
                         'I', "ingotIron",
                         'R', "dustRedstone",
-                        'C', RailcraftItem.circuit.getRecipeObject(ItemCircuit.EnumCircuit.SIGNAL));
+                        'C', EnumSignal.BLOCK_SIGNAL.getItem();
             }
 
             // Define Signal Sequencer Box


### PR DESCRIPTION
Signal Block Relay Boxes are much cheaper than Block Signals but can be used to create Signal Blocks additionally to the other things they can do, making actual Block Signals almost redundant for anything but aesthetics. By making the Relay Box require a Block Signal, it gets more expensive and will probably only be used where really necessary.

If you don't like the change, just close this.