### PR TITLE
Make Magnifying Glass localize its chat messages properly

### DIFF
--- a/src/main/java/mods/railcraft/common/items/ItemMagnifyingGlass.java
+++ b/src/main/java/mods/railcraft/common/items/ItemMagnifyingGlass.java
@@ -17,6 +17,7 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.ChatComponentTranslation
 import net.minecraft.world.World;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.entity.player.EntityInteractEvent;
@@ -131,7 +132,7 @@ public class ItemMagnifyingGlass extends ItemRailcraft implements IActivationBlo
             ChatPlugin.sendLocalizedChat(player, "railcraft.gui.mag.glass.aspect.dual", top.getLocalizationTag(), bottom.getLocalizationTag());
             returnValue = true;
         } else if (t instanceof TileSignalBase) {
-            ChatPlugin.sendLocalizedChat(player, "railcraft.gui.mag.glass.aspect", ((TileSignalBase) t).getSignalAspect().getLocalizationTag());
+            ChatPlugin.sendLocalizedChat(player, "railcraft.gui.mag.glass.aspect", new ChatComponentTranslation(((TileSignalBase) t).getSignalAspect().getLocalizationTag()));
             returnValue = true;
         }
         return returnValue;

--- a/src/main/java/mods/railcraft/common/plugins/forge/ChatPlugin.java
+++ b/src/main/java/mods/railcraft/common/plugins/forge/ChatPlugin.java
@@ -31,12 +31,12 @@ public class ChatPlugin {
     }
 
     public static void sendLocalizedChat(EntityPlayer player, String msg, Object... args) {
-        player.addChatMessage(getMessage(String.format(LocalizationPlugin.translate(msg), args)));
+        player.addChatMessage(getLocalizedMessage(msg, args));
     }
 
     public static void sendLocalizedChatFromClient(EntityPlayer player, String msg, Object... args) {
         if (Game.isNotHost(player.worldObj))
-            sendLocalizedChat(player, msg, args);
+            player.addChatMessage(getMessage(String.format(LocalizationPlugin.translate(msg), args)));
     }
 
     public static void sendLocalizedChatFromServer(EntityPlayer player, String msg, Object... args) {


### PR DESCRIPTION
Fixes #407.
Not sure about `ChatPlugin.sendLocalizedChatFromClient`, I left that as it was before because I wasn't sure if it's needed for anything.
See #589.