### PR TITLE
adding foundation to village workshop

### DIFF
--- a/src/main/java/mods/railcraft/common/worldgen/ComponentWorkshop.java
+++ b/src/main/java/mods/railcraft/common/worldgen/ComponentWorkshop.java
@@ -180,6 +180,21 @@ public class ComponentWorkshop extends StructureVillagePieces.Village {
             if (EnumMachineBeta.ENGINE_STEAM_HOBBY.isAvaliable() && RailcraftConfig.machinesRequirePower())
                 placeEngine(world, 9, 1, 6, sbb);
         }
+		
+		
+        // foundation
+        for (int k = 0; k < 11; ++k) {
+			for (int l = 4; l < 11; ++l) {
+				this.clearCurrentPositionBlocksUpwards(world, l, 6, k, sbb);
+				this.func_151554_b(world, Blocks.cobblestone, 0, l, -1, k, sbb);
+			}
+		}
+        for (int k = 1; k < 6; ++k) {
+			for (int l = 0; l < 4; ++l) {
+				this.clearCurrentPositionBlocksUpwards(world, l, 6, k, sbb);
+				this.func_151554_b(world, Blocks.cobblestone, 0, l, -1, k, sbb);
+			}
+		}
 
         placeChest(world, 9, 1, 4, 3, random, sbb);
 


### PR DESCRIPTION
Leaving foundation as cobblestone for now. This will be replaced with sandstone in desert villages.
The foundation could be brick if you want it to match the building construction, but I'll leave that up to you.

![2015-07-28_09 24 37](https://cloud.githubusercontent.com/assets/5705846/8937586/6f459de2-350e-11e5-967d-36f8d29ae76a.png)