### PR TITLE
Fire blockBreak events for EntityTunnelBore.java

### DIFF
--- a/src/main/java/mods/railcraft/common/carts/EntityTunnelBore.java
+++ b/src/main/java/mods/railcraft/common/carts/EntityTunnelBore.java
@@ -8,6 +8,11 @@
  */
 package mods.railcraft.common.carts;
 
+import com.mojang.authlib.GameProfile;
+
+import net.minecraft.world.WorldServer;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.world.BlockEvent.BreakEvent;
 import mods.railcraft.api.carts.CartTools;
 import mods.railcraft.api.carts.ILinkableCart;
 import mods.railcraft.api.carts.bore.IBoreHead;
@@ -708,6 +713,16 @@ public class EntityTunnelBore extends CartContainerBase implements IInventory, I
 
         if (!canMineBlock(x, y, z, block, meta))
             return false;
+        
+        // Start of Event Fire
+        GameProfile railcraftFakePlayer = new GameProfile(UUID.fromString("41C82C87-7AfB-4024-BA57-13D2C99CAE78"), "[Railcraft]");
+        BreakEvent breakEvent = new BreakEvent(x, y, z, worldObj, worldObj.getBlock(x, y, z), worldObj.getBlockMetadata(x, y, z), net.minecraftforge.common.util.FakePlayerFactory.get((WorldServer)worldObj, railcraftFakePlayer));
+        MinecraftForge.EVENT_BUS.post(breakEvent);
+
+        if (breakEvent.isCanceled()) {
+            return false;
+        }
+        // End of Event Fire
 
         ArrayList<ItemStack> items = block.getDrops(worldObj, x, y, z, meta, 0);
 


### PR DESCRIPTION
This will fire a blockBreak event using the fake player of [Railcraft].  Allows server owners to stop the block break if device should be blocked in a specific location.

Tested and confirmed working: 9/19/2015

Signed-off-by: Mike Howe - Dockter <mike@mcsnetworks.com>