### PR TITLE
Fix #695

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 allprojects {
-    apply plugin: 'java'
-    sourceCompatibility = 1.6
-    targetCompatibility = 1.6
+	apply plugin: 'java'
+	sourceCompatibility = 1.6
+	targetCompatibility = 1.6
 }
 
 evaluationDependsOn(':version')
@@ -72,8 +72,8 @@ configurations{
 }
 
 dependencies {
-	api 'net.industrial-craft:industrialcraft-2:2.2.717-experimental:api'
-	api 'com.mod-buildcraft:buildcraft:6.4.11:dev'
+	api 'net.industrial-craft:industrialcraft-2:2.2.780-experimental:api'
+	api 'com.mod-buildcraft:buildcraft:6.4.16:dev'
 }
 
 processResources
@@ -134,6 +134,8 @@ jar {
 				exclude '**/ic2/api/network/**'
 				exclude '**/ic2/api/event/**'
 				exclude '**/ic2/api/reactor/**'
+				exclude '**/ic2/api/package-info.java'
+				exclude '**/ic2/api/package-info.class'
 			}
 		}
 	}
@@ -144,7 +146,7 @@ jar {
 	into ('forestry/api') {
 		from project.apiForestry + "/LICENSE.txt"
 	}
-        into ('thaumcraft/api') {
+		into ('thaumcraft/api') {
 		from project.apiThaumcraft + "/LICENSE"
 	}
 	into ('cofh/api') {
@@ -239,6 +241,8 @@ task devJar ( type: Zip, dependsOn: devJarSigned ) {
 				exclude '**/ic2/api/network/**'
 				exclude '**/ic2/api/event/**'
 				exclude '**/ic2/api/reactor/**'
+				exclude '**/ic2/api/package-info.java'
+				exclude '**/ic2/api/package-info.class'
 			}
 		}
 	}


### PR DESCRIPTION
This change prevents that issue by removing `package-info`, making FML not recognizing the `package-info` as a valid, full ic2 api. For those inner packages, because they are full, so we can keep them and they should function properly.
Updated ic2 and buildcraft version also.