### PR TITLE
Classic Compatiblity Patch...

### DIFF
--- a/src/main/java/mods/railcraft/common/carts/EntityCartEnergyCESU.java
+++ b/src/main/java/mods/railcraft/common/carts/EntityCartEnergyCESU.java
@@ -21,12 +21,9 @@ import mods.railcraft.common.plugins.ic2.IC2Plugin;
  * @author CovertJaguar <http://www.railcraft.info>
  */
 public class EntityCartEnergyCESU extends EntityCartEnergy {
-	
-	boolean classic = false;
-	
+		
     public EntityCartEnergyCESU(World world) {
         super(world);
-        classic = ModuleIC2.classic;
     }
 
     public EntityCartEnergyCESU(World world, double d, double d1, double d2) {
@@ -68,7 +65,7 @@ public class EntityCartEnergyCESU extends EntityCartEnergy {
     @Override
     public ItemStack getIC2Item() {
     	//IC2 Classic so no RenderCrash Happens
-        return IC2Plugin.getItem(classic ? "mfsUnit" : "cesuUnit");
+        return IC2Plugin.getItem(ModuleIC2.classic ? "mfsUnit" : "cesuUnit");
     }
 
 }

--- a/src/main/java/mods/railcraft/common/carts/EntityCartEnergyCESU.java
+++ b/src/main/java/mods/railcraft/common/carts/EntityCartEnergyCESU.java
@@ -8,8 +8,12 @@
  */
 package mods.railcraft.common.carts;
 
+import java.util.Locale;
+
+import cpw.mods.fml.common.Loader;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
+import mods.railcraft.common.modules.ModuleIC2;
 import mods.railcraft.common.plugins.forge.LocalizationPlugin;
 import mods.railcraft.common.plugins.ic2.IC2Plugin;
 
@@ -17,9 +21,12 @@ import mods.railcraft.common.plugins.ic2.IC2Plugin;
  * @author CovertJaguar <http://www.railcraft.info>
  */
 public class EntityCartEnergyCESU extends EntityCartEnergy {
-
+	
+	boolean classic = false;
+	
     public EntityCartEnergyCESU(World world) {
         super(world);
+        classic = ModuleIC2.classic;
     }
 
     public EntityCartEnergyCESU(World world, double d, double d1, double d2) {
@@ -60,7 +67,8 @@ public class EntityCartEnergyCESU extends EntityCartEnergy {
 
     @Override
     public ItemStack getIC2Item() {
-        return IC2Plugin.getItem("cesuUnit");
+    	//IC2 Classic so no RenderCrash Happens
+        return IC2Plugin.getItem(classic ? "mfsUnit" : "cesuUnit");
     }
 
 }

--- a/src/main/java/mods/railcraft/common/carts/EntityCartEnergyMFE.java
+++ b/src/main/java/mods/railcraft/common/carts/EntityCartEnergyMFE.java
@@ -10,6 +10,7 @@ package mods.railcraft.common.carts;
 
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
+import mods.railcraft.common.modules.ModuleIC2;
 import mods.railcraft.common.plugins.forge.LocalizationPlugin;
 import mods.railcraft.common.plugins.ic2.IC2Plugin;
 
@@ -19,8 +20,11 @@ import mods.railcraft.common.plugins.ic2.IC2Plugin;
  */
 public class EntityCartEnergyMFE extends EntityCartEnergy {
 
+	boolean classic;
+	
     public EntityCartEnergyMFE(World world) {
         super(world);
+        classic = ModuleIC2.classic;
     }
 
     public EntityCartEnergyMFE(World world, double d, double d1, double d2) {
@@ -41,17 +45,17 @@ public class EntityCartEnergyMFE extends EntityCartEnergy {
 
     @Override
     public int getTier() {
-        return 3;
+        return classic ? 2 : 3;
     }
 
     @Override
     public int getCapacity() {
-        return 4000000;
+        return classic ? 600000 : 4000000;
     }
 
     @Override
     public int getTransferLimit() {
-        return 512;
+        return classic ? 128 : 512;
     }
 
     @Override

--- a/src/main/java/mods/railcraft/common/carts/EntityCartEnergyMFE.java
+++ b/src/main/java/mods/railcraft/common/carts/EntityCartEnergyMFE.java
@@ -19,12 +19,9 @@ import mods.railcraft.common.plugins.ic2.IC2Plugin;
  * @author CovertJaguar <http://www.railcraft.info>
  */
 public class EntityCartEnergyMFE extends EntityCartEnergy {
-
-	boolean classic;
 	
     public EntityCartEnergyMFE(World world) {
         super(world);
-        classic = ModuleIC2.classic;
     }
 
     public EntityCartEnergyMFE(World world, double d, double d1, double d2) {
@@ -45,17 +42,17 @@ public class EntityCartEnergyMFE extends EntityCartEnergy {
 
     @Override
     public int getTier() {
-        return classic ? 2 : 3;
+        return ModuleIC2.classic ? 2 : 3;
     }
 
     @Override
     public int getCapacity() {
-        return classic ? 600000 : 4000000;
+        return ModuleIC2.classic ? 600000 : 4000000;
     }
 
     @Override
     public int getTransferLimit() {
-        return classic ? 128 : 512;
+        return ModuleIC2.classic ? 128 : 512;
     }
 
     @Override

--- a/src/main/java/mods/railcraft/common/carts/EntityCartEnergyMFSU.java
+++ b/src/main/java/mods/railcraft/common/carts/EntityCartEnergyMFSU.java
@@ -1,0 +1,55 @@
+package mods.railcraft.common.carts;
+
+import ic2.api.item.IC2Items;
+import mods.railcraft.common.plugins.forge.LocalizationPlugin;
+import net.minecraft.item.ItemStack;
+import net.minecraft.world.World;
+
+public class EntityCartEnergyMFSU extends EntityCartEnergy {
+
+	public EntityCartEnergyMFSU(World world) {
+		super(world);
+	}
+
+    public EntityCartEnergyMFSU(World world, double d, double d1, double d2) {
+        this(world);
+        setPosition(d, d1 + (double) yOffset, d2);
+        motionX = 0.0D;
+        motionY = 0.0D;
+        motionZ = 0.0D;
+        prevPosX = d;
+        prevPosY = d1;
+        prevPosZ = d2;
+    }
+
+	@Override
+	public int getTier() {
+		return 3;
+	}
+
+	@Override
+	public String getInventoryName() {
+        return LocalizationPlugin.translate(EnumCart.ENERGY_MFSU.getTag());
+	}
+
+	@Override
+	public ItemStack getIC2Item() {
+		return IC2Items.getItem("mfsUnit");
+	}
+
+	@Override
+	public int getCapacity() {
+		return 10000000;
+	}
+
+	@Override
+	public int getTransferLimit() {
+		return 512;
+	}
+
+	@Override
+	public ICartType getCartType() {
+		return EnumCart.ENERGY_MFSU;
+	}
+
+}

--- a/src/main/java/mods/railcraft/common/carts/EnumCart.java
+++ b/src/main/java/mods/railcraft/common/carts/EnumCart.java
@@ -51,6 +51,7 @@ public enum EnumCart implements ICartType {
     ENERGY_BATBOX(0, EntityCartEnergyBatBox.class, null),
     ENERGY_CESU(0, EntityCartEnergyCESU.class, null),
     ENERGY_MFE(0, EntityCartEnergyMFE.class, null),
+    ENERGY_MFSU(1, EntityCartEnergyMFSU.class, null),
     HOPPER(0, EntityMinecartHopper.class, new ItemStack(Blocks.hopper)),
     TRACK_LAYER(1, EntityCartTrackLayer.class, null),
     TRACK_REMOVER(1, EntityCartTrackRemover.class, null),

--- a/src/main/java/mods/railcraft/common/modules/ModuleFactory.java
+++ b/src/main/java/mods/railcraft/common/modules/ModuleFactory.java
@@ -455,13 +455,13 @@ public class ModuleFactory extends RailcraftModule {
         }
 
         if (IC2Plugin.isModInstalled()) {
-            ItemStack crushedIron = IC2Plugin.getItem("crushedIronOre");
-            ItemStack crushedGold = IC2Plugin.getItem("crushedGoldOre");
-            ItemStack crushedCopper = IC2Plugin.getItem("crushedCopperOre");
-            ItemStack crushedTin = IC2Plugin.getItem("crushedTinOre");
-            ItemStack crushedSilver = IC2Plugin.getItem("crushedSilverOre");
+            ItemStack crushedIron = IC2Plugin.getItem(ModuleIC2.classic ? "ironDust" : "crushedIronOre");
+            ItemStack crushedGold = IC2Plugin.getItem(ModuleIC2.classic ? "goldDust" : "crushedGoldOre");
+            ItemStack crushedCopper = IC2Plugin.getItem(ModuleIC2.classic ? "copperDust" : "crushedCopperOre");
+            ItemStack crushedTin = IC2Plugin.getItem(ModuleIC2.classic ? "tinDust" : "crushedTinOre");
+            ItemStack crushedSilver = IC2Plugin.getItem(ModuleIC2.classic ? "silverDust" : "crushedSilverOre");
             ItemStack crushedLead = IC2Plugin.getItem("crushedLeadOre");
-            ItemStack crushedUranium = IC2Plugin.getItem("crushedUraniumOre");
+            ItemStack crushedUranium = IC2Plugin.getItem(ModuleIC2.classic ? "uraniumDrop" : "crushedUraniumOre");
 
             if (RailcraftConfig.canCrushOres()) {
                 registerCrushedOreRecipe(new ItemStack(Blocks.iron_ore), crushedIron);

--- a/src/main/java/mods/railcraft/common/modules/ModuleIC2.java
+++ b/src/main/java/mods/railcraft/common/modules/ModuleIC2.java
@@ -10,6 +10,8 @@ package mods.railcraft.common.modules;
 
 import ic2.api.recipe.Recipes;
 import org.apache.logging.log4j.Level;
+
+import cpw.mods.fml.common.Loader;
 import net.minecraft.block.Block;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
@@ -33,6 +35,7 @@ public class ModuleIC2 extends RailcraftModule {
 
     public static Item lapotronUpgrade;
 //    private static Item creosoteWood;
+    public static boolean classic;
 
     @Override
     public boolean canModuleLoad() {
@@ -46,7 +49,7 @@ public class ModuleIC2 extends RailcraftModule {
 
     @Override
     public void initFirst() {
-
+    	classic = Loader.isModLoaded("IC2-Classic-Spmod");
         BlockDetector.registerBlock();
         RailcraftBlocks.registerBlockMachineGamma();
 
@@ -60,7 +63,8 @@ public class ModuleIC2 extends RailcraftModule {
 
         EnumCart.ENERGY_BATBOX.setup();
         EnumCart.ENERGY_MFE.setup();
-        EnumCart.ENERGY_CESU.setup();
+        if(classic) EnumCart.ENERGY_MFSU.setup();
+        else EnumCart.ENERGY_CESU.setup();
 
 //        id = RailcraftConfig.getItemId("item.creosote.wood");
 //        if(id > 0){
@@ -116,19 +120,40 @@ public class ModuleIC2 extends RailcraftModule {
             }
         }
 
-        ItemStack cesu = IC2Plugin.getItem("cesuUnit");
-        if (cesu != null) {
-            EnumCart cart = EnumCart.ENERGY_CESU;
-            cart.setContents(cesu);
-            ItemStack stack = cart.getCartItem();
-            if (stack != null) {
-                CraftingPlugin.addShapedRecipe(stack, new Object[]{
-                    "E",
-                    "M",
-                    'E', cesu,
-                    'M', Items.minecart
-                });
-                CraftingPlugin.addShapelessRecipe(new ItemStack(Items.minecart), stack);
+        if(!classic)
+        {
+            ItemStack cesu = IC2Plugin.getItem("cesuUnit");
+            if (cesu != null) {
+                EnumCart cart = EnumCart.ENERGY_CESU;
+                cart.setContents(cesu);
+                ItemStack stack = cart.getCartItem();
+                if (stack != null) {
+                    CraftingPlugin.addShapedRecipe(stack, new Object[]{
+                        "E",
+                        "M",
+                        'E', cesu,
+                        'M', Items.minecart
+                    });
+                    CraftingPlugin.addShapelessRecipe(new ItemStack(Items.minecart), stack);
+                }
+            }
+        }
+        else
+        {
+            ItemStack mfsu = IC2Plugin.getItem("mfsUnit");
+            if (mfsu != null) {
+                EnumCart cart = EnumCart.ENERGY_MFSU;
+                cart.setContents(mfsu);
+                ItemStack stack = cart.getCartItem();
+                if (stack != null) {
+                    CraftingPlugin.addShapedRecipe(stack, new Object[]{
+                        "E",
+                        "M",
+                        'E', mfsu,
+                        'M', Items.minecart
+                    });
+                    CraftingPlugin.addShapelessRecipe(new ItemStack(Items.minecart), stack);
+                }
             }
         }
 

--- a/src/main/java/mods/railcraft/common/util/misc/EntityIDs.java
+++ b/src/main/java/mods/railcraft/common/util/misc/EntityIDs.java
@@ -40,6 +40,7 @@ public class EntityIDs {
     public static final int CART_ENERGY_BATBOX = 87;
     public static final int CART_ENERGY_CESU = 88;
     public static final int CART_ENERGY_MFE = 89;
+    public static final int CART_ENERGY_MFSU = 90;
     // ENTITY ITEMS
     public static final int ENTITY_ITEM_FIRESTONE = 75;
     public static final int ENTITY_ITEM_FIREPROOF = 76;


### PR DESCRIPTION
-Added: MFSU Cart (only for IC2 Classic)
-Added: MFE Cart Adjust to IC2 Classic when its loaded
-Changed: CESU Cart get not loaded when IC2 Classic is installed.
-Changed: CESU Cart shows as MFSU If it get loaded for Any Reason if Classic installed
-Missing: MFSU Cart (When i make Textures people die so yeah)

If anything is wrong. Suggest something