### PR TITLE
Fixes #627 Furnace recipe config effect flipped

### DIFF
--- a/src/main/java/mods/railcraft/common/core/RailcraftConfig.java
+++ b/src/main/java/mods/railcraft/common/core/RailcraftConfig.java
@@ -316,8 +316,8 @@ public class RailcraftConfig {
                 keys.remove();
         }
 
-        loadRecipeProperty("minecraft.furnace", "creosote", false, "change to '{t}=true' to add smelting recipes for Creosote Oil to the vanilla furnace");
-        loadRecipeProperty("railcraft.track", "useAltRecipes", false, "change to '{t}=false' to use track recipes more similar to vanilla minecraft");
+        loadRecipeProperty("minecraft.furnace", "creosote", false, "change to '{t}=false' to add smelting recipes for Creosote Oil to the vanilla furnace");
+        loadRecipeProperty("railcraft.track", "useAltRecipes", false, "change to '{t}=true' to use track recipes more similar to vanilla minecraft");
         loadRecipeProperty("railcraft.rockCrusher", "ores", true, "change to '{t}=false' to prevent the game from crushing ores into dusts (only available if IC2 installed)");
         loadRecipeProperty("railcraft.misc", "gunpowder", true, "change to '{t}=false' to disable the sulfur, saltpeter, charcoal dust recipe for gunpowder");
         creosoteTorchOutput = get(CAT_RECIPES + ".railcraft.misc", "creosote.torches", 0, 6, 16, "set the output of the creosote and woool recipe for torches, setting to 0 will disable'\nmin=0, default=6, max=16");

--- a/src/main/java/mods/railcraft/common/core/RailcraftConfig.java
+++ b/src/main/java/mods/railcraft/common/core/RailcraftConfig.java
@@ -317,7 +317,7 @@ public class RailcraftConfig {
         }
 
         loadRecipeProperty("minecraft.furnace", "creosote", false, "change to '{t}=true' to add smelting recipes for Creosote Oil to the vanilla furnace");
-        loadRecipeProperty("railcraft.track", "useAltRecipes", false, "change to '{t}=true' to use track recipes more similar to vanilla minecraft");
+        loadRecipeProperty("railcraft.track", "useAltRecipes", false, "change to '{t}=false' to use track recipes more similar to vanilla minecraft");
         loadRecipeProperty("railcraft.rockCrusher", "ores", true, "change to '{t}=false' to prevent the game from crushing ores into dusts (only available if IC2 installed)");
         loadRecipeProperty("railcraft.misc", "gunpowder", true, "change to '{t}=false' to disable the sulfur, saltpeter, charcoal dust recipe for gunpowder");
         creosoteTorchOutput = get(CAT_RECIPES + ".railcraft.misc", "creosote.torches", 0, 6, 16, "set the output of the creosote and woool recipe for torches, setting to 0 will disable'\nmin=0, default=6, max=16");


### PR DESCRIPTION
I was coding a function to invert the value in the config file, leaving another config called hasAlreadyInverted.railcraft.track to make it run once, but Yopu's comment makes more sense, to simply invert the description;

I have the half-baked code if you still want to take the other approach;